### PR TITLE
Fix pip3 command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The modules in this collection are written for Python 3.6 or newer.
 
 Most modules and roles in this collection require the `proxmoxer` and `requests` Python module.
 
-- Installation with `pip` (venv recommended): `pip3 install proxomxer requests`
+- Installation with `pip` (venv recommended): `pip3 install proxmoxer requests`
 
 To install this collection: `ansible-galaxy collection install maxhoesel.proxmox`
 


### PR DESCRIPTION
There was a very small typo in the pip3 command. Normally wouldn't submit something but it's a command to copy/paste 😄 