### PR TITLE
Fix issues with LXC container roles

### DIFF
--- a/roles/lxc_container/meta/argument_specs.yml
+++ b/roles/lxc_container/meta/argument_specs.yml
@@ -83,7 +83,7 @@ argument_specs:
           onboot: no
           netif:
             net0: name=eth0,bridge=vmbr0,ip=dhcp,firewall=0
-          pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}'
+          #pubkey: '{{ lookup("file", "~/.ssh/id_rsa.pub") }}' this is checked by the argspec validator, disable
           unprivileged: yes
       lxccreate_timeout:
         type: int

--- a/roles/lxc_container/tasks/main.yml
+++ b/roles/lxc_container/tasks/main.yml
@@ -14,12 +14,16 @@
 
 - name: Download OS Template
   ansible.builtin.include_tasks: ostemplate.yml
-  delegate_to: "{{ pve_host }}"
+  args:
+    apply:
+      delegate_to: "{{ pve_host }}"
 
 - name: Provision container
   ansible.builtin.include_tasks: provision.yml
 
 - name: Boostrap container
   ansible.builtin.include_tasks: bootstrap.yml
-  delegate_to: "{{ pve_host }}"
   when: lxccreate_bootstrap and pve_lxccreate_task.changed
+  args:
+    apply:
+      delegate_to: "{{ pve_host }}"

--- a/roles/lxc_container/tasks/provision.yml
+++ b/roles/lxc_container/tasks/provision.yml
@@ -1,4 +1,4 @@
-- name: Container is present
+- name: Container is present # noqa args[module]
   community.general.proxmox: '{{ lxccreate_module_args }}'
   delegate_to: localhost
   register: pve_lxccreate_task

--- a/roles/lxc_container_to_ostemplate/tasks/main.yml
+++ b/roles/lxc_container_to_ostemplate/tasks/main.yml
@@ -16,11 +16,15 @@
 
 - name: Prepare cluster for template creation
   ansible.builtin.include_tasks: prepare.yml
-  delegate_to: "{{ pve_host }}"
+  args:
+    apply:
+      delegate_to: "{{ pve_host }}"
 
 - name: Generate OS Template
   ansible.builtin.include_tasks: generate.yml
-  delegate_to: "{{ pve_host }}"
+  args:
+    apply:
+      delegate_to: "{{ pve_host }}"
   when:
     (not lxcostemplate_overwrite and not lxcostemplate_existing_image.stat.exists) or
     lxcostemplate_overwrite


### PR DESCRIPTION
This PR fixes a few bugs that have crept in with the most recent release:

- argspec no longer errors out if ~/.ssh/id_rsa.pub is not present
- include_tasks now properly delegated to the pve host