### PR TITLE
pve: Add support for installing microcode

### DIFF
--- a/roles/pve/README.md
+++ b/roles/pve/README.md
@@ -4,9 +4,10 @@ A role to perform basic setup tasks on a PVE node, such as repository and CPU co
 
 The following features are available and can be enabled/disabled individually:
 
+- Install CPU microcode for AMD/Intel from the `non-free` debian source component
 - Set a PVE repository (enterprise, no-subscription, test) (required)
 - Set the PVE root password (required)
-- Set the CPU governor to save power or improve performance
+- Optimize the CPU governor selection
 - Support PCIe Passthrough by enabling the required modules
 
 ## Requirements
@@ -28,7 +29,21 @@ The following features are available and can be enabled/disabled individually:
 - Please note that this role does not configure your subscription key, you will have to do so yourself
 - Default: `no-subscription`
 
+
 ### CPU Settings
+
+##### `pve_install_ucode`
+- Whether to install the microcode packages for your appropriate CPU
+- This may not be required on fresh installs of PVE 8 and newer, as Debian 12 ships with this microcode by default
+- For Debian 11 and lower (PVE <= 7), this requires enabling the `non-free` repository
+- For Debian 12 and up (PVE >=8), the `non-free-firmware` repository will be enabled instead, if not already present
+- Default: `false`
+
+##### `pve_reboot_for_ucode`
+- Whether to reboot the host after microcode has been installed (if required)
+- If set to `false`, you may have to manually reboot the node to load the microcode
+- This has no effect if `pve_install_ucode` is disabled
+- Default: `true`
 
 ##### `pve_set_cpu`
 - Whether to modify the CPU configuration, such as the chosen governor.

--- a/roles/pve/defaults/main.yml
+++ b/roles/pve/defaults/main.yml
@@ -5,3 +5,6 @@ pve_cpu_governor: performance
 
 pve_enable_pcie_passthrough: no
 pve_pcie_reboot_for_kernel: yes
+
+pve_install_ucode: false
+pve_reboot_for_ucode: true

--- a/roles/pve/handlers/main.yml
+++ b/roles/pve/handlers/main.yml
@@ -1,6 +1,23 @@
 - name: update initramfs
   command: update-initramfs -u -k all
 
-- name: reboot host to enable vifo kernel modules
-  ansible.builtin.reboot:
+# These wrapper handlers are needed to ensure that we only reboot when allowed, and only reboot once
+- name: reboot host to enable pcie passthrough
+  meta: noop
+  changed_when: true
+  notify: _reboot host
   when: pve_pcie_reboot_for_kernel
+
+- name: reboot host to update microcode
+  meta: noop
+  changed_when: true
+  notify: _reboot host
+  when: pve_reboot_for_ucode
+
+- name: _reboot host
+  ansible.builtin.reboot:
+
+- name: restart cpu-governor service
+  ansible.builtin.systemd:
+    name: cpu-governor.service
+    state: restarted

--- a/roles/pve/handlers/main.yml
+++ b/roles/pve/handlers/main.yml
@@ -3,19 +3,22 @@
 
 # These wrapper handlers are needed to ensure that we only reboot when allowed, and only reboot once
 - name: reboot host to enable pcie passthrough
-  meta: noop
+  ansible.builtin.debug:
+    msg: "Rebooting host to enable pice passthrough"
   changed_when: true
   notify: _reboot host
   when: pve_pcie_reboot_for_kernel
 
 - name: reboot host to update microcode
-  meta: noop
+  ansible.builtin.debug:
+    msg: "Rebooting host to update microcode"
   changed_when: true
   notify: _reboot host
   when: pve_reboot_for_ucode
 
 - name: _reboot host
   ansible.builtin.reboot:
+    reboot_timeout: 900
 
 - name: restart cpu-governor service
   ansible.builtin.systemd:

--- a/roles/pve/meta/argument_specs.yml
+++ b/roles/pve/meta/argument_specs.yml
@@ -54,3 +54,18 @@ argument_specs:
           - Whether to automatically reboot the node to load the required kernel modules
           - If set to I(false), you may have to manually reboot the node to enable PCIe passthrough
           - This has no effect if I(pve_enable_pcie_passthrough) is disabled
+      pve_install_ucode:
+        type: bool
+        default: false
+        description:
+          - Whether to install the microcode packages for your appropriate CPU
+          - This may not be required on fresh installs of PVE 8 and newer, as Debian 12 ships with this microcode by default
+          - For Debian 11 and lower (PVE <= 7), this requires enabling the `non-free` repository
+          - For Debian 12 and up (PVE >=8), the `non-free-firmware` repository will be enabled instead, if not already present
+      pve_reboot_for_ucode:
+        type: bool
+        default: true
+        description:
+          - Whether to reboot the host after microcode has been installed (if required)
+          - If set to I(false), you may have to manually reboot the node to load the microcode
+          - This has no effect if I(pve_install_ucode) is disabled

--- a/roles/pve/tasks/cpu.yml
+++ b/roles/pve/tasks/cpu.yml
@@ -2,14 +2,18 @@
   ansible.builtin.apt:
     name: linux-cpupower
 
-- name: Get current governor
-  ansible.builtin.shell: "cat /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor"
-  changed_when: no
-  check_mode: no
-  register: _pve_current_governor
+- name: cpu-governor service is installed
+  ansible.builtin.template:
+    src: templates/cpu-governor.service.j2
+    dest: /etc/systemd/system/cpu-governor.service
+    owner: root
+    group: root
+    mode: "644"
+  notify: restart cpu-governor service
 
-- name: Set CPU governor to {{ pve_cpu_governor }}
-  ansible.builtin.command: "cpupower frequency-set -g {{ pve_cpu_governor }}"
-  when: >
-    (_pve_current_governor.stdout_lines | unique | select | list).0 != pve_cpu_governor or
-    (_pve_current_governor.stdout_lines | unique | select | list | length) > 1
+- name: cpu-governor service is enabled and running
+  ansible.builtin.systemd:
+    name: cpu-governor.service
+    enabled: yes
+    state: started
+    daemon_reload: yes

--- a/roles/pve/tasks/main.yml
+++ b/roles/pve/tasks/main.yml
@@ -15,6 +15,9 @@
 
 - name: Setup PBS repo
   include_tasks: repo.yml
+- name: Install microcode
+  ansible.builtin.include_tasks: ucode.yml
+  when: pve_install_ucode
 - name: Configure CPU governor
   include_tasks: cpu.yml
   when: pve_set_cpu

--- a/roles/pve/tasks/pcie_passthrough.yml
+++ b/roles/pve/tasks/pcie_passthrough.yml
@@ -6,7 +6,7 @@
     group: root
     mode: "644"
   when: '"GenuineIntel" in ansible_processor | unique'
-  notify: reboot host to enable vifo kernel modules
+  notify: reboot host to enable pcie passthrough
 
 - name: vfio kernel modules are enabled
   copy:
@@ -17,4 +17,4 @@
     mode: "644"
   notify:
     - update initramfs
-    - reboot host to enable vifo kernel modules
+    - reboot host to enable pcie passthrough

--- a/roles/pve/tasks/repo.yml
+++ b/roles/pve/tasks/repo.yml
@@ -1,20 +1,16 @@
-- name: "Enable Repository: {{ pve_repo_type }}"
+- name: "Selected PVE repository is enabled"
   apt_repository:
     repo: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} {{ pve_repo_names[pve_repo_type] }}"
     filename: "{{ pve_repo_names[pve_repo_type] }}"
     update_cache: no
 
-- name: Get other repositories
-  set_fact:
-    _pve_disable_repos: "{{ pve_repo_names.keys() | difference([pve_repo_type]) }}"
-
-- name: Other repositories are disabled
+- name: Other PVE repositories are disabled
   apt_repository:
     repo: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} {{ pve_repo_names[item] }}"
     state: absent
     filename: "{{ pve_repo_names[item] }}"
     update_cache: no
-  loop: "{{ _pve_disable_repos }}"
+  loop: "{{ pve_disable_repos }}"
 
 - name: Update APT cache
   apt:

--- a/roles/pve/tasks/ucode.yml
+++ b/roles/pve/tasks/ucode.yml
@@ -1,0 +1,13 @@
+- name: deb repository configuration is present
+  ansible.builtin.template:
+    src: templates/sources.list.j2
+    dest: /etc/apt/sources.list
+    owner: root
+    group: root
+    mode: "644"
+
+- name: Microcode package is installed
+  ansible.builtin.apt:
+    name: "{{ pve_ucode_package[ansible_processor[1]] }}"
+    update_cache: yes
+  notify: reboot host to update microcode

--- a/roles/pve/templates/cpu-governor.service.j2
+++ b/roles/pve/templates/cpu-governor.service.j2
@@ -1,0 +1,7 @@
+[Unit]
+Description=Adjust CPU governor after boot
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cpupower -c all frequency-set -g {{ pve_cpu_governor }}
+[Install]
+WantedBy=multi-user.target

--- a/roles/pve/templates/sources.list.j2
+++ b/roles/pve/templates/sources.list.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+
+deb http://deb.debian.org/debian {{ ansible_distribution_release }} main contrib {{ pve_non_free_firmware_text }}
+deb-src http://deb.debian.org/debian {{ ansible_distribution_release }} main contrib {{ pve_non_free_firmware_text }}
+
+deb http://deb.debian.org/debian-security/ {{ ansible_distribution_release }}-security main contrib {{ pve_non_free_firmware_text }}
+deb-src http://deb.debian.org/debian-security/ {{ ansible_distribution_release }}-security main contrib {{ pve_non_free_firmware_text }}
+
+deb http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib {{ pve_non_free_firmware_text }}
+deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib {{ pve_non_free_firmware_text }}

--- a/roles/pve/vars/main.yml
+++ b/roles/pve/vars/main.yml
@@ -4,7 +4,7 @@ pve_repo_names:
   test: pvetest
 pve_disable_repos: "{{ pve_repo_names.keys() | difference([pve_repo_type]) }}"
 
-pve_non_free_firmware_text: "{{ pve_install_ucode | ternary(ansible_distribution_major_version < 12 | ternary('non-free', 'non-free-firmware')) }}"
+pve_non_free_firmware_text: "{{ pve_install_ucode | ternary(((ansible_distribution_major_version | int) < 12) | ternary('non-free', 'non-free-firmware'), '') }}"
 pve_ucode_package:
   AuthenticAMD: amd64-microcode
   GenuineIntel: intel-microcode

--- a/roles/pve/vars/main.yml
+++ b/roles/pve/vars/main.yml
@@ -2,3 +2,9 @@ pve_repo_names:
   no-subscription: pve-no-subscription
   enterprise: pve-enterprise
   test: pvetest
+pve_disable_repos: "{{ pve_repo_names.keys() | difference([pve_repo_type]) }}"
+
+pve_non_free_firmware_text: "{{ pve_install_ucode | ternary(ansible_distribution_major_version < 12 | ternary('non-free', 'non-free-firmware')) }}"
+pve_ucode_package:
+  AuthenticAMD: amd64-microcode
+  GenuineIntel: intel-microcode


### PR DESCRIPTION
This PR lets the `pve` role install microcode on supported machines using the non-free repository.
This is disabled by default to preserve compatibility