### PR TITLE
pbs_client: remove support for ubuntu

### DIFF
--- a/roles/pbs_client/README.md
+++ b/roles/pbs_client/README.md
@@ -7,9 +7,8 @@ Additionally, a backup job can be configured and scheduled.
 
 ## Requirements
 
-- Ubuntu 20.04
-    - Note that Ubuntu 22.04 is currently broken because of [this issue](https://bugzilla.proxmox.com/show_bug.cgi?id=4191)
-- Debian 11 or later
+- Supported distros:
+    - Debian 11, 12
 - Root access via `become: yes` or equivalent
 
 ## Role Variables

--- a/roles/pbs_client/molecule/default/molecule.yml
+++ b/roles/pbs_client/molecule/default/molecule.yml
@@ -1,21 +1,9 @@
 ---
 platforms:
-  # Currently broken because of https://bugzilla.proxmox.com/show_bug.cgi?id=4191
-  #- name: pbs-client-ubuntu-22
-  #  groups:
-  #    - ubuntu
-  #  image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
-  #  volumes:
-  #    - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  #  cgroupns_mode: host
-  #  privileged: true
-  #  override_command: false
-  #  pre_build_image: true
-
-  - name: pbs-client-ubuntu-20
+  - name: pbs-client-debian-12
     groups:
-      - ubuntu
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+      - debian
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/pbs_client/tasks/install.yml
+++ b/roles/pbs_client/tasks/install.yml
@@ -1,16 +1,27 @@
-# The Buster repository doesn't work with the PVE-provided key, so we use the bullseye version
-# for all Debian-based destributions
+- name: Remove key from trusted.gpg.d if present
+  ansible.builtin.file:
+    # the old version of this role only ever installed the bullseye key, so thats the only one we need to remove.
+    path: /etc/apt/trusted.gpg.d/proxmox-release-bullseye.gpg
+    state: absent
+
+- name: Keyrings directory is present # noqa risky-file-permissions
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    owner: root
+    group: root
+
 - name: Proxmox APT key is present
   ansible.builtin.get_url:
-    url: https://enterprise.proxmox.com/debian/proxmox-release-bullseye.gpg
-    dest: /etc/apt/trusted.gpg.d/proxmox-release-bullseye.gpg
+    url: https://enterprise.proxmox.com/debian/proxmox-release-{{ ansible_distribution_release }}.gpg
+    dest: /etc/apt/keyrings/proxmox-release-{{ ansible_distribution_release }}.gpg
     owner: root
     group: root
     mode: "644"
 
 - name: Proxmox Backup Server APT repository is present
   ansible.builtin.apt_repository:
-    repo: deb http://download.proxmox.com/debian/pbs-client bullseye main
+    repo: "deb [signed-by=/etc/apt/keyrings/proxmox-release-{{ ansible_distribution_release }}.gpg] http://download.proxmox.com/debian/pbs-client {{ ansible_distribution_release }} main"
     update_cache: yes
 
 - name: Proxmox Backup Client is installed


### PR DESCRIPTION
the upstream proxmox repository no longer mentions Ubuntu as supported, and both 20.04 and 22.04 have required workarounds in the past. While 24.04 currently seems to work with the bookworm repository, this is not guaranteed and ultimately not something i want to support going forward.

This patch thus removes support for Ubuntu nodes in the pbs_client role.