### PR TITLE
pve: add PVE9 support, fix repository config

### DIFF
--- a/roles/pve/README.md
+++ b/roles/pve/README.md
@@ -4,9 +4,9 @@ A role to perform basic setup tasks on a PVE node, such as repository and CPU co
 
 The following features are available and can be enabled/disabled individually:
 
-- Install CPU microcode for AMD/Intel from the `non-free` debian source component
 - Set a PVE repository (enterprise, no-subscription, test) (required)
-- Set the PVE root password (required)
+- Install CPU microcode for AMD/Intel from the `non-free` debian source component
+- Set the PVE root password
 - Optimize the CPU governor selection
 - Support PCIe Passthrough by enabling the required modules
 
@@ -20,7 +20,7 @@ The following features are available and can be enabled/disabled individually:
 ##### `pve_root_password`
 - Password for the root user
 - Must be a string of at least 8 characters
-- Required: `true`
+- Required: `false`
 - Default: undefined
 
 ##### `pve_repo_type`
@@ -34,9 +34,9 @@ The following features are available and can be enabled/disabled individually:
 
 ##### `pve_install_ucode`
 - Whether to install the microcode packages for your appropriate CPU
-- This may not be required on fresh installs of PVE 8 and newer, as Debian 12 ships with this microcode by default
-- For Debian 11 and lower (PVE <= 7), this requires enabling the `non-free` repository
-- For Debian 12 and up (PVE >=8), the `non-free-firmware` repository will be enabled instead, if not already present
+- On PVE 7 and below, this will also enable the required `non-free` repository containing the ucode package
+- On PVE 8, this will activate the `non-free-firmware` component instead
+- On PVE 9 and above, this repository is already enabled, so only the CPU ucode package will be installed
 - Default: `false`
 
 ##### `pve_reboot_for_ucode`
@@ -53,12 +53,14 @@ The following features are available and can be enabled/disabled individually:
 - Which CPU governor to use for all CPU cores on each node
 - You can check which CPU governors are available for your CPU and driver by running
   `cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors` on one of your nodes.
-  - The `intel_pstate` driver hands much of the CPU scaling off to the hardware and only supports two governors - `powersave` and `performance`.
-    See the [kernel docs](https://www.kernel.org/doc/html/v4.19/admin-guide/pm/intel_pstate.html) for more information.
-  - Older Intel CPUs under (`intel_cpufreq`) and AMD CPUs can use any [generic governor](https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt).
-  - Proxmox defaults to `performance` due to potential [BSODs in Windows guests when running with variable frequency](https://forum.proxmox.com/threads/windows-7-x64-vms-crashing-randomly-during-process-termination.18238/#post-93273)
-  - `ondemand` and `schedutil` both scale CPU frequency dynamically and may improve power consumption.
-- Default: `performance`. Set to `schedutil` if you want to save power and aware of the limitations mentioned above.
+- If you have an AMD CPU (Zen2 or newer) with a new Kernel (6.5 or newer, PVE8) or have an Intel CPU (Sandy Bridge or newer):
+    - the system will use a hardware-backed scaling driver, either `intel_pstate` or `amd_pstate_(epp)`.
+    - You can set a preference with either `powersave` or `performance`
+- If you are on an older Kernel or have an older CPU:
+  - You can use any [generic governor](https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt).
+- Proxmox defaults to `performance` due to potential [BSODs in Windows guests when running with variable frequency](https://forum.proxmox.com/threads/windows-7-x64-vms-crashing-randomly-during-process-termination.18238/#post-93273)
+- More Information on the [Arch Wiki](https://wiki.archlinux.org/title/CPU_frequency_scaling#Scaling_drivers)
+- Default: `performance`. To save power, set to `powersave` on modern systems with a hardware driver, or `schedutil` on systems without.
 
 ### PCIe Passthrough
 

--- a/roles/pve/meta/argument_specs.yml
+++ b/roles/pve/meta/argument_specs.yml
@@ -18,11 +18,11 @@ argument_specs:
         description:
           - Password for the root user
           - Must be a string of at least 8 characters
-        required: yes
+        required: false
       pve_repo_type:
         type: str
-        choices: ['enterprise', 'no-subscription', 'test']
-        default: 'no-subscription'
+        choices: ["enterprise", "no-subscription", "test"]
+        default: "no-subscription"
         description:
           - Selects which PVE repository is enabled for pulling updates
           - Please note that this role does not configure your subscription key, you will have to do so yourself

--- a/roles/pve/tasks/checks.yml
+++ b/roles/pve/tasks/checks.yml
@@ -1,6 +1,4 @@
 - name: Verify required variables are valid
   assert:
     that:
-      - pve_root_password is defined
-      - pve_root_password | length >= 8
-      - pve_repo_type in ["no-subscription", "enterprise", "testing"]
+      - pve_repo_type in ["no-subscription", "enterprise", "test"]

--- a/roles/pve/tasks/main.yml
+++ b/roles/pve/tasks/main.yml
@@ -1,26 +1,25 @@
 - name: Perform checks
   include_tasks: checks.yml
 
-# This step is required to properly decrypt the root password
-# if it is stored in ansible-vault
-- name: Decrypt root password
-  set_fact:
-    pve_root_password: "{{ pve_root_password }}"
-  no_log: true
-
 - name: Root password is set
   user:
     name: root
     password: "{{ pve_root_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
+  when: pve_root_password is defined
 
 - name: Setup PBS repo
   include_tasks: repo.yml
+
 - name: Install microcode
   ansible.builtin.include_tasks: ucode.yml
-  when: pve_install_ucode
+  when:
+    - pve_install_ucode
+    - ansible_distribution_major_version | int >= 13
+
 - name: Configure CPU governor
   include_tasks: cpu.yml
   when: pve_set_cpu
+
 - name: Enable PCIe passthrough
   include_tasks: pcie_passthrough.yml
   when: pve_enable_pcie_passthrough

--- a/roles/pve/tasks/repo.yml
+++ b/roles/pve/tasks/repo.yml
@@ -1,16 +1,73 @@
-- name: "Selected PVE repository is enabled"
-  apt_repository:
-    repo: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} {{ pve_repo_names[pve_repo_type] }}"
-    filename: "{{ pve_repo_names[pve_repo_type] }}"
-    update_cache: no
+- name: Configure list-based repositories (PVE <=8)
+  block:
+    - name: Selected PVE repository is enabled
+      ansible.builtin.apt_repository:
+        repo: "deb {{ pve_repo_baseurl[pve_repo_type] }}/pve {{ ansible_distribution_release }} {{ pve_repo_names[pve_repo_type] }}"
+        filename: "{{ pve_repo_names[pve_repo_type] }}"
+        update_cache: no
+    - name: Other PVE repositories are disabled
+      ansible.builtin.apt_repository:
+        repo: "deb {{ pve_repo_baseurl[item] }}/pve {{ ansible_distribution_release }} {{ pve_repo_names[item] }}"
+        state: absent
+        filename: "{{ pve_repo_names[item] }}"
+        update_cache: no
+      loop: "{{ pve_disable_repos }}"
 
-- name: Other PVE repositories are disabled
-  apt_repository:
-    repo: "deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} {{ pve_repo_names[item] }}"
-    state: absent
-    filename: "{{ pve_repo_names[item] }}"
-    update_cache: no
-  loop: "{{ pve_disable_repos }}"
+    - name: Retrieve configured ceph release
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: set -o pipefail && cat /etc/apt/sources.list.d/ceph.list | cut -d ' ' -f 2 | cut -d '-' -f 2
+      register: _pve_ceph_release
+      changed_when: false
+      check_mode: false
+    - name: Configure ceph repository
+      ansible.builtin.copy:
+        content: |
+          deb {{ pve_repo_baseurl[pve_repo_type] }}/ceph-{{ _pve_ceph_release.stdout }} {{ ansible_distribution_release }} {{ pve_ceph_repo_names[pve_repo_type] }}
+        dest: /etc/apt/sources.list.d/ceph.list
+        owner: root
+        group: root
+        mode: "644"
+  when: ansible_distribution_major_version | int <= 12
+
+- name: Configure sources-based repositories (PVE >=9)
+  block:
+    - name: Enable selected PVE repository
+      ansible.builtin.deb822_repository:
+        name: "{{ pve_repo_names[pve_repo_type] }}"
+        types: deb
+        uris: "{{ pve_repo_baseurl[pve_repo_type] }}/pve"
+        suites: "{{ ansible_distribution_release }}"
+        components: "{{ pve_repo_names[pve_repo_type] }}"
+        signed_by: /usr/share/keyrings/proxmox-archive-keyring.gpg
+        enabled: true
+    - name: Disable other PVE repositories
+      ansible.builtin.deb822_repository:
+        name: "{{ pve_repo_names[item] }}"
+        types: deb
+        uris: "{{ pve_repo_baseurl[item] }}/pve"
+        suites: "{{ ansible_distribution_release }}"
+        components: "{{ pve_repo_names[item] }}"
+        signed_by: /usr/share/keyrings/proxmox-archive-keyring.gpg
+        enabled: false
+      loop: "{{ pve_disable_repos }}"
+
+    - name: Retrieve configured ceph release
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: set -o pipefail && grep URIs /etc/apt/sources.list.d/ceph.sources | cut -d '-' -f 2
+      register: _pve_ceph_release
+      changed_when: false
+      check_mode: false
+    - name: Configure ceph repository
+      ansible.builtin.deb822_repository:
+        name: "ceph"
+        types: deb
+        uris: "{{ pve_repo_baseurl[pve_repo_type] }}/ceph-{{ _pve_ceph_release.stdout }}"
+        suites: "{{ ansible_distribution_release }}"
+        components: "{{ pve_ceph_repo_names[pve_repo_type] }}"
+        signed_by: /usr/share/keyrings/proxmox-archive-keyring.gpg
+  when: ansible_distribution_major_version | int >= 13
 
 - name: Update APT cache
   apt:

--- a/roles/pve/tasks/ucode.yml
+++ b/roles/pve/tasks/ucode.yml
@@ -5,6 +5,7 @@
     owner: root
     group: root
     mode: "644"
+  when: ansible_distribution_major_version | int <= 12
 
 - name: Microcode package is installed
   ansible.builtin.apt:

--- a/roles/pve/vars/main.yml
+++ b/roles/pve/vars/main.yml
@@ -1,7 +1,15 @@
+pve_repo_baseurl:
+  no-subscription: http://download.proxmox.com/debian
+  test: http://download.proxmox.com/debian
+  enterprise: https://enterprise.proxmox.com/debian
 pve_repo_names:
   no-subscription: pve-no-subscription
   enterprise: pve-enterprise
-  test: pvetest
+  test: "{{ 'pvetest' if (ansible_distribution_major_version | int) < 13 else 'pve-test' }}"
+pve_ceph_repo_names:
+  no-subscription: no-subscription
+  enterprise: enterprise
+  test: test
 pve_disable_repos: "{{ pve_repo_names.keys() | difference([pve_repo_type]) }}"
 
 pve_non_free_firmware_text: "{{ pve_install_ucode | ternary(((ansible_distribution_major_version | int) < 12) | ternary('non-free', 'non-free-firmware'), '') }}"


### PR DESCRIPTION
This commit adds support for the new sources-style config format
from Debian 13. It also fixes #98 by replacing the incorrect repository
URL for enterprise and accounting for the ceph repo.